### PR TITLE
Add stats_back button and improve queue time formatting

### DIFF
--- a/menus.py
+++ b/menus.py
@@ -48,6 +48,7 @@ def build_country_menu(country: str, lang: str):
         [InlineKeyboardButton(BUTTONS[lang]["7d"], callback_data=f"{country[:2]}_7d"),
          InlineKeyboardButton(BUTTONS[lang]["30d"], callback_data=f"{country[:2]}_30d")],
         [InlineKeyboardButton(BUTTONS[lang]["archive"], callback_data=f"{country}_archive")],
+        [InlineKeyboardButton(BUTTONS[lang]["stats_back"], callback_data="stats_back")],
         [InlineKeyboardButton(BUTTONS[lang]["menu"], callback_data="menu")],
     ]
 

--- a/texts.py
+++ b/texts.py
@@ -10,17 +10,23 @@ MAIN_MENU = {
     "en": {
         "welcome": (
             "<b>Welcome to the Border Queue Bot!</b> 👋\n\n"
-            "Here you can track border crossing queues from <b>Belarus ➝ EU</b> in real time, "
-            "view historical statistics, and estimate the speed of passing through.\n\n"
-            "➡️ Choose an option below to get started:"
+            "Here you can track queues at border crossing points from <b>Belarus ➝ EU</b>:\n"
+            "• in real-time;\n"
+            "• view historical statistics;\n"
+            "• estimate border crossing speed;\n"
+            "• receive notifications for your saved cars.\n\n"
+            "➡️ <i>Choose an option below to get started:</i>"
         )
     },
     "ru": {
         "welcome": (
             "<b>Добро пожаловать в бота Очереди на границе!</b> 👋\n\n"
-            "Здесь вы можете отслеживать очереди на границе из <b>Беларуси ➝ ЕС</b> в реальном времени, "
-            "смотреть историческую статистику и оценивать скорость прохождения границы.\n\n"
-            "➡️ Выберите действие ниже, чтобы начать:"
+            "Здесь вы можете отслеживать очереди на границе из <b>Беларуси ➝ ЕС</b>:\n"
+            "• в реальном времени;\n"
+            "• смотреть историческую статистику;\n"
+            "• оценивать скорость прохождения границы;\n"
+            "• получать уведомления по сохраненным машинам.\n\n"
+            "➡️ <i>Выберите действие ниже, чтобы начать:</i>"
         )
     }   
 }
@@ -174,11 +180,11 @@ ESTIMATIONS = {
             "grigorovschina": 4,
         },
         "border_points_names": {
-            "benyakoni": "Benyakoni",
-            "brest_bts": "Brest BTS (\"Varshavskiy Most\")",
-            "kamenny_log": "Kamenny Log",
-            "grigorovschina": "Grigorovschina",
-            "kozlovichi": "Kozlovichi",
+            "benyakoni": "<b>Benyakoni</b>",
+            "brest_bts": "<b>Brest BTS (\"Varshavskiy Most\")</b>",
+            "kamenny_log": "<b>Kamenny Log</b>",
+            "grigorovschina": "<b>Grigorovschina</b>",
+            "kozlovichi": "<b>Kozlovichi</b>",
         }
     },
     "ru": {
@@ -207,11 +213,11 @@ ESTIMATIONS = {
             "grigorovschina": 4,
         },
         "border_points_names": {
-            "benyakoni": "Бенякони",
-            "brest_bts": "Брест БТС (\"Варшавский мост\")",
-            "kamenny_log": "Каменный Лог",
-            "grigorovschina": "Григоровщина",
-            "kozlovichi": "Козловичи",
+            "benyakoni": "<b>Бенякони</b>",
+            "brest_bts": "<b>Брест БТС (\"Варшавский мост\")</b>",
+            "kamenny_log": "<b>Каменный Лог</b>",
+            "grigorovschina": "<b>Григоровщина</b>",
+            "kozlovichi": "<b>Козловичи</b>",
         }
     }   
 }
@@ -233,11 +239,11 @@ CARTRACKING = {
         ),
         "car_added": (
             "<b>✅ Car Added</b>\n\n"
-            "The car with license plate <code>{}</code> has been added for tracking."
+            "The car with license plate <b>{}</b> has been added for tracking."
         ),
         "car_removed": (
             "<b>✅ Car Removed</b>\n\n"
-            "The car with license plate <code>{}</code> has been removed from tracking."
+            "The car with license plate <b>{}</b> has been removed from tracking."
         ),
         "car_added_error": (
             "❌ Invalid plate format.\n\n"
@@ -258,6 +264,9 @@ CARTRACKING = {
             "• License Plate: <b>{}</b>\n"
             "• Position in Queue: <b>{}</b>\n"
             "• Registered: <b>{}</b>\n"
+        ),
+        "car_time_in_queue": (
+            "Time in Queue: <b>{}</b> hours and <>b{}</b> minutes"
         ),
         "car_notification_settings": (
             "<b>Notification settings for car <code>{}</code></b>"
@@ -322,11 +331,11 @@ CARTRACKING = {
         ),
         "car_added": (
             "<b>✅ Машина добавлена</b>\n\n"
-            "Машина с номером <code>{}</code> была добавлена для отслеживания."
+            "Машина с номером <b>{}</b> была добавлена для отслеживания."
         ),
         "car_removed": (
             "<b>✅ Машина удалена</b>\n\n"
-            "Машина с номером <code>{}</code> была удалена из отслеживания."
+            "Машина с номером <b>{}</b> была удалена из отслеживания."
         ),
         "car_added_error": (
             "❌ Неверный формат номера.\n\n"
@@ -347,6 +356,9 @@ CARTRACKING = {
             "• Номерной знак: <b>{}</b>\n"
             "• Позиция в очереди: <b>{}</b>\n"
             "• Зарегистрирован: <b>{}</b>\n"
+        ),
+        "car_time_in_queue": (
+            "Время в очереди: <b>{}</b> часов и <b>{}</b> минут"
         ),
         "car_notification_settings": (
             "<b>Настройки уведомлений для машины <code>{}</code></b>"
@@ -401,6 +413,7 @@ BUTTONS = {
     "en": {
         "current": "Current queue info",
         "stats":"Historical queue data",
+        "stats_back": "🔙 Historical queue data",
         "estimations": "Estimate border speed",
         "country_lt": "Lithuania 🇱🇹",
         "country_lv": "Latvia 🇱🇻",
@@ -453,6 +466,7 @@ BUTTONS = {
     "ru": {
         "current": "Актуальная информация",
         "stats":"Исторические данные",
+        "stats_back": "🔙 Исторические данные",
         "estimations": "Оценить скорость границы",
         "country_lt": "Литва 🇱🇹",
         "country_lv": "Латвия 🇱🇻",
@@ -482,7 +496,7 @@ BUTTONS = {
         "october": "Октябрь",
         "november": "Ноябрь",
         "december": "Декабрь",
-        "car_tracking": "Сохраненные машины",
+        "car_tracking": "Отслеживание сохраненных машин",
         "car_tracking_back": "🔙 Сохраненные машины",
         "car_type_passenger": "Легковая 🚗",
         "car_type_freight": "Грузовая 🚚",

--- a/user_utils.py
+++ b/user_utils.py
@@ -1,11 +1,9 @@
 from telegram import User, InputMediaPhoto, InlineKeyboardMarkup
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-from sqlalchemy import func
-from datetime import datetime
 from db_functions import get_local_session
 from models import DBUser, UserAction, UserNotification, UserCars
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 import time
 import httpx
 from io import BytesIO
@@ -134,7 +132,7 @@ def fetch_data_from_api(url):
     else:
         raise Exception(f"Failed to fetch data: {response.status_code}, {response.text}")
 
-def get_queue_length_current(checkpoint_id: str):
+def get_queue_length_current(checkpoint_id: str, utc_offset_hours: int = 3):
     try:
         url = "https://belarusborder.by/info/checkpoint?token=bts47d5f-6420-4f74-8f78-42e8e4370cc4"
 
@@ -148,7 +146,11 @@ def get_queue_length_current(checkpoint_id: str):
                 countBus = cp['countBus']
                 countMotorcycle = cp['countMotorcycle']
         
-        return countCar, countTruck, countBus, countMotorcycle
+        # Get current timestamp with UTC offset
+        current_timestamp = datetime.now(timezone.utc) + timedelta(hours=utc_offset_hours)
+        current_timestamp = current_timestamp.strftime('%Y-%m-%d %H:%M')
+
+        return countCar, countTruck, countBus, countMotorcycle, current_timestamp
         
     except Exception as e:
         print(f"Error: {e}")


### PR DESCRIPTION
This PR adds a "stats_back" button to the historical stats menu, improves queue time calculation and formatting, and updates main menu and car tracking texts for better clarity and consistency.

Key changes:

- Added "stats_back" button for easier navigation in stats menus.
- Improved queue time calculation and display for tracked cars.
- Updated main menu and car tracking texts for both English and Russian.
- Enhanced formatting for border point names and car status details.